### PR TITLE
Add useRootNavigator to modal delegate

### DIFF
--- a/lib/src/prompt/delegate.dart
+++ b/lib/src/prompt/delegate.dart
@@ -78,6 +78,7 @@ abstract class ChoicePrompt {
     Clip clipBehavior = Clip.antiAlias,
     ShapeBorder? shape,
     double maxHeightFactor = 0.6,
+    bool useRootNavigator = false,
   }) {
     return (context, modal) {
       return showModalBottomSheet(
@@ -91,6 +92,7 @@ abstract class ChoicePrompt {
         barrierColor: barrierColor,
         enableDrag: enableDrag,
         isScrollControlled: true,
+        useRootNavigator: useRootNavigator,
         builder: (_) {
           final MediaQueryData mq = MediaQueryData.fromView(View.of(context));
           final double topObstructions = mq.viewPadding.top;


### PR DESCRIPTION
Simply exposes useRootNavigator to the modal delegate to allow the modal. I use a shell navigator setup and want the choice to display on top of everything.